### PR TITLE
Fix paths

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -105,7 +105,7 @@ read -n 1 -r -p "Would you like to start skydrive-d now? [y/n] "
 echo ""
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-	./skydrive-d
+	./src/skydrive-d
 else
 	echo -e "You choose to start skydrive-d later."
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -77,6 +77,10 @@ if [ "$reset_conf_flag" -eq 1 ] ; then
 	rm -vf "$HOMEDIR/.lcrc" "$SKYDRIVED_CONF_FILE"
 	echo "Specify the directory to synchronize with SkyDrive [$HOMEDIR/SkyDrive][ENTER]:"
 	read -r SKYDRIVE_DIR
+	#If no user input, lets default to home directory
+	if [ -z $SKYDRIVE_DIR ]; then
+		SKYDRIVE_DIR=$HOMEDIR/SkyDrive
+	fi
 	if_make_dir $SKYDRIVE_DIR
 	build_lcrc $SKYDRIVE_DIR
 else


### PR DESCRIPTION
The `setup.sh` script would fail to create `~/SkyDrive` if there was no user input, thus running `if_make_dir` with no options. It now defaults to `~/SkyDrive` if no input. Also fixed is the `skydrive-d` path.
