### PR TITLE
Fix synchronize with OneDrive and path

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -109,7 +109,9 @@ read -n 1 -r -p "Would you like to start skydrive-d now? [y/n] "
 echo ""
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-	./src/skydrive-d
+	cd ./src/
+	./skydrive-d
+	:
 else
 	echo -e "You choose to start skydrive-d later."
 fi

--- a/src/skydrive-d
+++ b/src/skydrive-d
@@ -26,7 +26,7 @@ SKYDRIVED_ROOT_PATH=`grep "rootPath:" $SKYDRIVED_CONF_FILE | cut -d ' ' -f2`
 # entry point for deep sync
 exec_deep_sync() {
 	echo "Deep synchronization not done yet..."
-	# python synchronize.py
+	python ./synchronize.py
 }
 
 # function exec_skydrive_mv $from $to

--- a/src/synchronize.py
+++ b/src/synchronize.py
@@ -8,7 +8,7 @@
 
 import sys, os
 import yaml
-import entries
+from entries import * 
 
 settingsFile = open(os.path.expanduser("~/.skydrive/user.conf"), "r");
 settingsMap = yaml.safe_load(settingsFile)


### PR DESCRIPTION
I've fixed the path (yet again) in `setup.sh` to `cd` to `src` before we execute `skydrive-d`. The reason behind this is that `skydrive-d` calls for `python ./synchronize.py` which does not work when we are not in `src`. As said in the one commit message, this seems like a temporary fix.

`synchronize.py` was also fixed. Before commit 359b785, `synchronize.py` would output `NameError: name 'DirectoryEntry' is not defined` which is the reasoning behind the commit.
