### PR TITLE
Fix user home path when running with sudo

### DIFF
--- a/onedrive_d/config.py
+++ b/onedrive_d/config.py
@@ -16,7 +16,7 @@ else:
 	# when in SUDO, fix the HOME_PATH
 	# may not be necessary on most OSes
 	# buggy!!
-	HOME_PATH = os.path.split(HOME_PATH)[0] + "/" + LOCAL_USER
+	HOME_PATH = os.path.split(HOME_PATH)[0] + "home/" + LOCAL_USER
 
 f = open(HOME_PATH + "/.onedrive/user.conf", "r")
 CONF = yaml.safe_load(f)

--- a/onedrive_d/util.py
+++ b/onedrive_d/util.py
@@ -10,7 +10,7 @@ if OS_USER == None or OS_USER == "":
 else:
 	# when in SUDO, fix the HOME_PATH
 	# may not be necessary on most OSes
-	HOME_PATH = os.path.split(HOME_PATH)[0] + "/" + OS_USER
+	HOME_PATH = os.path.split(HOME_PATH)[0] + "home/" + OS_USER
 
 OS_DIST =  platform.linux_distribution()
 

--- a/onedrive_d/util.py
+++ b/onedrive_d/util.py
@@ -2,15 +2,14 @@
 
 import os, sys, pwd, yaml, subprocess, platform
 
-HOME_PATH = os.path.expanduser("~")
+HOME_PATH = os.path.expanduser('~'+os.getenv("SUDO_USER"))
+
+
 OS_USER = os.getenv("SUDO_USER")
 if OS_USER == None or OS_USER == "":
 	# the user isn't running sudo
 	OS_USER = os.getenv("USER")
-else:
-	# when in SUDO, fix the HOME_PATH
-	# may not be necessary on most OSes
-	HOME_PATH = os.path.split(HOME_PATH)[0] + "home/" + OS_USER
+
 
 OS_DIST =  platform.linux_distribution()
 

--- a/onedrive_d/util.py
+++ b/onedrive_d/util.py
@@ -80,7 +80,7 @@ def setupDaemon():
 			exclusion_list = "exclude: \"\""
 			print "There is nothing in the exclusion list."
 	else:
-		exclusion_list = "exclude: \"\""
+		exclusion_list = "exclude: \"\"\n"
 		print "Skipped."
 	
 	while True:


### PR DESCRIPTION
`util.py` would fail to create `~/.onedrive` when running as root due to incorrect path. `HOME_PATH` would default to `//username` instead of `/home/username`. 

There might be a better way of handling this, rather than hardcoding `home` to `HOME_PATH`.
